### PR TITLE
Fixed typo in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ plugins: [
     options: {
       aws: {
         accessKeyId: 'youraccesskeyhere',
-        secretAccessKeyId: 'hunter2',
+        secretAccessKey: 'hunter2',
       },
       buckets: ['your-s3-bucket.com'],
     },


### PR DESCRIPTION
Without this commit we would get a validation error:

![image](https://user-images.githubusercontent.com/20717348/39550778-51f38e64-4e17-11e8-9a91-f561a4d09f4c.png)

Which wouldn't make it passed the build phase

